### PR TITLE
wallet: fix account creation error message in step1

### DIFF
--- a/web-frontend/src/pages/CreateAccount/StepOne.tsx
+++ b/web-frontend/src/pages/CreateAccount/StepOne.tsx
@@ -34,7 +34,7 @@ export default function StepOne() {
     }
 
     if (isAlreadyExists(nickname, accounts)) {
-      setError({ nickname: Intl.t('errors.nickname-already-exists') });
+      setError({ nickname: Intl.t('errors.duplicate-nickname') });
       return false;
     }
 


### PR DESCRIPTION
Fix account create error message in step1 when the user tried to enter a name that had already been used.

**BEFORE**
![image](https://github.com/massalabs/station-massa-wallet/assets/72019005/27654b7e-d332-44f0-b6b2-a0bef84ffe90)

**AFTER**
![image](https://github.com/massalabs/station-massa-wallet/assets/72019005/9b29b5ba-468d-40d7-970c-572dd2cce2ab)


**For PM**
**Time estimation :** 10min
**Time result :** 10min