### PR TITLE
Add Dynamic Address Render

### DIFF
--- a/web-frontend/src/pages/Home/Home.tsx
+++ b/web-frontend/src/pages/Home/Home.tsx
@@ -1,7 +1,7 @@
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { AccountObject } from '../../models/AccountModel';
-import { formatStandard, Unit, maskAddress } from '../../utils/massaFormat';
+import { formatStandard, Unit } from '../../utils/massaFormat';
 import { useResource } from '../../custom/api';
 import { routeFor } from '../../utils';
 import Intl from '../../i18n/i18n';
@@ -23,22 +23,6 @@ export default function Home() {
     isLoading,
   } = useResource<AccountObject>(`accounts/${nickname}`);
 
-  const breakpoint = 1920; // Screen breakpoint value
-  const unformattedBalance = account?.candidateBalance ?? '0';
-  const balance = parseInt(unformattedBalance);
-  const formattedBalance = formatStandard(balance, Unit.NanoMAS);
-  const address = account?.address ?? '';
-  const formattedAddress = maskAddress(address);
-
-  const [screenWidth, setScreenWidth] = useState(window.innerWidth);
-  const [displayedContent, setDisplayedContent] = useState(formattedAddress);
-
-  // Function seems unnecessary,
-  // but it is needed to update the state of screenWidth
-  function handleResize() {
-    setScreenWidth(window.innerWidth);
-  }
-
   useEffect(() => {
     if (error) {
       navigate(routeFor('error'));
@@ -47,20 +31,10 @@ export default function Home() {
     }
   }, [account, navigate]);
 
-  // Call handleResize once after component mounts to log formattedAddress on page load
-  useEffect(() => {
-    window.addEventListener('resize', handleResize);
-    handleResize();
-    return () => {
-      window.removeEventListener('resize', handleResize);
-    };
-  }, []);
-
-  useEffect(() => {
-    screenWidth <= breakpoint
-      ? setDisplayedContent(formattedAddress)
-      : setDisplayedContent(address);
-  }, [screenWidth, breakpoint, address, formattedAddress]);
+  const unformattedBalance = account?.candidateBalance ?? '0';
+  const balance = parseInt(unformattedBalance);
+  const formattedBalance = formatStandard(balance, Unit.NanoMAS);
+  const address = account?.address ?? '';
 
   return (
     <WalletLayout menuItem={MenuItem.Home}>
@@ -103,7 +77,7 @@ export default function Home() {
               {Intl.t('home.title-account-address')}
             </p>
             <Clipboard
-              displayedContent={displayedContent}
+              displayedContent={address}
               rawContent={address}
               error={Intl.t('errors.no-content-to-copy')}
               className="flex flex-row items-center mas-body2 justify-between


### PR DESCRIPTION
BEFORE : 
![Screenshot from 2023-06-29 11-38-14](https://github.com/massalabs/station-massa-wallet/assets/90157528/3f7ab8c6-9dd3-4eba-9726-e203642958df)
 = static address 

AFTER : 

![Screenshot from 2023-06-30 17-41-29](https://github.com/massalabs/station-massa-wallet/assets/90157528/391c1866-5062-491b-90ac-8bbb353fa50a)




LEGACY : 
[Screencast from 29-06-2023 11:38:33.webm](https://github.com/massalabs/station-massa-wallet/assets/90157528/19346970-589c-45ff-a158-875f7ed9dfc5)
 = address render on screen bigger than 1920px 

Update : this feature demands the use of useEffect react hooks which are not optimal and may introduce bugs. Moreover, the current solution has a complexity of O(n) which is not optimal if we want to apply this effect elsewhere in our application. 

After meeting with mario, we have a proposition for you : 

Make the address string adaptable to the size of the object field using css with a complexity of O(1). Here is and example of the results :
![Screenshot from 2023-06-29 16-09-57](https://github.com/massalabs/station-massa-wallet/assets/90157528/748b126c-17db-49e3-b376-4320255c743b)
![Screenshot from 2023-06-29 16-10-08](https://github.com/massalabs/station-massa-wallet/assets/90157528/a07945a5-891a-4b4f-859e-6111fa15409b)

This does not respect design or respect standards so it is a proposition, feel free to give us feedback on this. If it is KO, I will search for a compromise between optimal code and product standards. 

