### PR TITLE
Prevent Enter key showing password

### DIFF
--- a/api/server/models/sign_request.go
+++ b/api/server/models/sign_request.go
@@ -92,6 +92,10 @@ func (m *SignRequest) ContextValidate(ctx context.Context, formats strfmt.Regist
 
 func (m *SignRequest) contextValidateCorrelationID(ctx context.Context, formats strfmt.Registry) error {
 
+	if swag.IsZero(m.CorrelationID) { // not required
+		return nil
+	}
+
 	if err := m.CorrelationID.ContextValidate(ctx, formats); err != nil {
 		if ve, ok := err.(*errors.Validation); ok {
 			return ve.ValidateName("correlationId")

--- a/api/server/models/sign_response.go
+++ b/api/server/models/sign_response.go
@@ -88,6 +88,10 @@ func (m *SignResponse) ContextValidate(ctx context.Context, formats strfmt.Regis
 
 func (m *SignResponse) contextValidateCorrelationID(ctx context.Context, formats strfmt.Registry) error {
 
+	if swag.IsZero(m.CorrelationID) { // not required
+		return nil
+	}
+
 	if err := m.CorrelationID.ContextValidate(ctx, formats); err != nil {
 		if ve, ok := err.(*errors.Validation); ok {
 			return ve.ValidateName("correlationId")

--- a/api/server/models/update_account_request.go
+++ b/api/server/models/update_account_request.go
@@ -184,6 +184,10 @@ func (m *UpdateAccountRequest) ContextValidate(ctx context.Context, formats strf
 
 func (m *UpdateAccountRequest) contextValidateAddress(ctx context.Context, formats strfmt.Registry) error {
 
+	if swag.IsZero(m.Address) { // not required
+		return nil
+	}
+
 	if err := m.Address.ContextValidate(ctx, formats); err != nil {
 		if ve, ok := err.(*errors.Validation); ok {
 			return ve.ValidateName("address")
@@ -197,6 +201,10 @@ func (m *UpdateAccountRequest) contextValidateAddress(ctx context.Context, forma
 }
 
 func (m *UpdateAccountRequest) contextValidateBalance(ctx context.Context, formats strfmt.Registry) error {
+
+	if swag.IsZero(m.Balance) { // not required
+		return nil
+	}
 
 	if err := m.Balance.ContextValidate(ctx, formats); err != nil {
 		if ve, ok := err.(*errors.Validation); ok {
@@ -212,6 +220,10 @@ func (m *UpdateAccountRequest) contextValidateBalance(ctx context.Context, forma
 
 func (m *UpdateAccountRequest) contextValidateCandidateBalance(ctx context.Context, formats strfmt.Registry) error {
 
+	if swag.IsZero(m.CandidateBalance) { // not required
+		return nil
+	}
+
 	if err := m.CandidateBalance.ContextValidate(ctx, formats); err != nil {
 		if ve, ok := err.(*errors.Validation); ok {
 			return ve.ValidateName("candidateBalance")
@@ -225,6 +237,10 @@ func (m *UpdateAccountRequest) contextValidateCandidateBalance(ctx context.Conte
 }
 
 func (m *UpdateAccountRequest) contextValidateKeyPair(ctx context.Context, formats strfmt.Registry) error {
+
+	if swag.IsZero(m.KeyPair) { // not required
+		return nil
+	}
 
 	if err := m.KeyPair.ContextValidate(ctx, formats); err != nil {
 		if ve, ok := err.(*errors.Validation); ok {

--- a/api/server/restapi/operations/massa_wallet_api.go
+++ b/api/server/restapi/operations/massa_wallet_api.go
@@ -497,6 +497,6 @@ func (o *MassaWalletAPI) AddMiddlewareFor(method, path string, builder middlewar
 	}
 	o.Init()
 	if h, ok := o.handlers[um][path]; ok {
-		o.handlers[method][path] = builder(h)
+		o.handlers[um][path] = builder(h)
 	}
 }

--- a/wails-frontend/src/pages/ImportPrivateKey/PromptPrivateKey.tsx
+++ b/wails-frontend/src/pages/ImportPrivateKey/PromptPrivateKey.tsx
@@ -8,6 +8,7 @@ import { Password, Button, Stepper } from '@massalabs/react-ui-kit';
 import { Layout } from '../../layouts/Layout/Layout';
 
 import { IMPORT_STEPS } from '../../const/stepper';
+import { handleKeyDown } from '../../utils/handleKeyDown';
 
 // TODO: create i18n and move this to translation file
 const t = (key: string): string => {
@@ -58,7 +59,7 @@ function PromptPrivateKey() {
   return (
     <Layout>
       <Stepper step={0} steps={IMPORT_STEPS} />
-      <form ref={form} onSubmit={handleSubmit}>
+      <form ref={form} onSubmit={handleSubmit} onKeyDown={handleKeyDown}>
         <h1 className="mas-title pt-6">{req.Msg}</h1>
         <p className="mas-body pt-4">Enter your Private Key</p>
         <div className="pt-4">

--- a/wails-frontend/src/pages/backupKeyPairs.tsx
+++ b/wails-frontend/src/pages/backupKeyPairs.tsx
@@ -85,6 +85,7 @@ function BackupKeyPairs() {
   }
 
   async function handleSubmit(e: SyntheticEvent) {
+    console.log('submit');
     e.preventDefault();
     if (!validate(e)) return;
 

--- a/wails-frontend/src/pages/backupKeyPairs.tsx
+++ b/wails-frontend/src/pages/backupKeyPairs.tsx
@@ -10,6 +10,7 @@ import Intl from '../i18n/i18n';
 import { Password, Button, Clipboard } from '@massalabs/react-ui-kit';
 import { Layout } from '../layouts/Layout/Layout';
 import { FiCopy, FiArrowRight } from 'react-icons/fi';
+import { handleKeyDown } from '../utils/handleKeyDown';
 
 function EnterKey() {
   return (
@@ -96,8 +97,8 @@ function BackupKeyPairs() {
 
   return (
     <Layout>
-      <form ref={form} onSubmit={handleSubmit}>
-        <div className="flex items-end gap-3 mb-4">
+      <form ref={form} onSubmit={handleSubmit} onKeyDown={handleKeyDown}>
+        <div className="flex items-end gap-3">
           <h1 className="mas-title">{Intl.t('backup.title')}</h1>
           <span>/</span>
           <h2 className="mas-h2">{walletName}</h2>

--- a/wails-frontend/src/pages/newPassword.tsx
+++ b/wails-frontend/src/pages/newPassword.tsx
@@ -14,6 +14,7 @@ import { FiLock } from 'react-icons/fi';
 import { Layout } from '../layouts/Layout/Layout';
 import { Password, Button, Stepper } from '@massalabs/react-ui-kit';
 import { IErrorObject } from '../utils';
+import { handleKeyDown } from '../utils/handleKeyDown';
 
 function NewPassword() {
   const navigate = useNavigate();
@@ -105,7 +106,7 @@ function NewPassword() {
           />
         </div>
       )}
-      <form ref={form} onSubmit={handleSubmit}>
+      <form ref={form} onSubmit={handleSubmit} onKeyDown={handleKeyDown}>
         <h1 className="mas-title">{req.Msg}</h1>
         <p className="mas-body pt-4">{getSubtitle()}</p>
         <div className="pt-4">

--- a/wails-frontend/src/pages/newPassword.tsx
+++ b/wails-frontend/src/pages/newPassword.tsx
@@ -54,8 +54,10 @@ function NewPassword() {
   const [errorConfirm, setErrorConfirm] = useState<IErrorObject | null>(null);
 
   function validate(e: SyntheticEvent) {
+    console.log('validate called');
     let valid = true;
     const form = parseForm(e);
+    console.log('formData: ', form);
     const { password, passwordConfirm } = form;
 
     // reset error state
@@ -96,6 +98,10 @@ function NewPassword() {
     save(e);
   }
 
+  function handleKeyDownWrapper(event: React.KeyboardEvent<HTMLFormElement>) {
+    handleKeyDown(event, handleSubmit);
+  }
+
   return (
     <Layout>
       {isImportAction && (
@@ -106,7 +112,7 @@ function NewPassword() {
           />
         </div>
       )}
-      <form ref={form} onSubmit={handleSubmit} onKeyDown={handleKeyDown}>
+      <form ref={form} onSubmit={handleSubmit} onKeyDown={handleKeyDownWrapper}>
         <h1 className="mas-title">{req.Msg}</h1>
         <p className="mas-body pt-4">{getSubtitle()}</p>
         <div className="pt-4">

--- a/wails-frontend/src/pages/newPassword.tsx
+++ b/wails-frontend/src/pages/newPassword.tsx
@@ -54,10 +54,8 @@ function NewPassword() {
   const [errorConfirm, setErrorConfirm] = useState<IErrorObject | null>(null);
 
   function validate(e: SyntheticEvent) {
-    console.log('validate called');
     let valid = true;
     const form = parseForm(e);
-    console.log('formData: ', form);
     const { password, passwordConfirm } = form;
 
     // reset error state
@@ -98,10 +96,6 @@ function NewPassword() {
     save(e);
   }
 
-  function handleKeyDownWrapper(event: React.KeyboardEvent<HTMLFormElement>) {
-    handleKeyDown(event, handleSubmit);
-  }
-
   return (
     <Layout>
       {isImportAction && (
@@ -112,7 +106,7 @@ function NewPassword() {
           />
         </div>
       )}
-      <form ref={form} onSubmit={handleSubmit} onKeyDown={handleKeyDownWrapper}>
+      <form ref={form} onSubmit={handleSubmit} onKeyDown={handleKeyDown}>
         <h1 className="mas-title">{req.Msg}</h1>
         <p className="mas-body pt-4">{getSubtitle()}</p>
         <div className="pt-4">

--- a/wails-frontend/src/pages/passwordPrompt.tsx
+++ b/wails-frontend/src/pages/passwordPrompt.tsx
@@ -18,7 +18,6 @@ import { Layout } from '../layouts/Layout/Layout';
 import Intl from '../i18n/i18n';
 import { formatStandard, maskAddress } from '../utils/massaFormat';
 import { toMAS } from '@massalabs/massa-web3';
-import { handleKeyDown } from '../utils/handleKeyDown';
 
 interface PromptRequestDeleteData {
   Nickname: string;
@@ -171,7 +170,7 @@ function PasswordPrompt() {
 
   return (
     <Layout>
-      <form ref={form} onSubmit={handleSubmit} onKeyDown={handleKeyDown}>
+      <form ref={form} onSubmit={handleSubmit}>
         <h1 className="mas-title">{getTitle()}</h1>
         <div className="mas-body pt-4 break-words max-w-xs">
           {getSubtitle()}

--- a/wails-frontend/src/pages/passwordPrompt.tsx
+++ b/wails-frontend/src/pages/passwordPrompt.tsx
@@ -18,6 +18,7 @@ import { Layout } from '../layouts/Layout/Layout';
 import Intl from '../i18n/i18n';
 import { formatStandard, maskAddress } from '../utils/massaFormat';
 import { toMAS } from '@massalabs/massa-web3';
+import { handleKeyDown } from '../utils/handleKeyDown';
 
 interface PromptRequestDeleteData {
   Nickname: string;
@@ -170,7 +171,7 @@ function PasswordPrompt() {
 
   return (
     <Layout>
-      <form ref={form} onSubmit={handleSubmit}>
+      <form ref={form} onSubmit={handleSubmit} onKeyDown={handleKeyDown}>
         <h1 className="mas-title">{getTitle()}</h1>
         <div className="mas-body pt-4 break-words max-w-xs">
           {getSubtitle()}

--- a/wails-frontend/src/utils/handleKeyDown.tsx
+++ b/wails-frontend/src/utils/handleKeyDown.tsx
@@ -1,9 +1,5 @@
-export function handleKeyDown(
-  event: React.KeyboardEvent<HTMLFormElement>,
-  handleSubmit: (e: React.SyntheticEvent) => Promise<void>,
-) {
-  if (event.key === 'Enter') {
-    event.preventDefault();
-    handleSubmit(event);
+export function handleKeyDown(e: React.KeyboardEvent<HTMLFormElement>) {
+  if (e.key === 'Enter') {
+    e.preventDefault();
   }
 }

--- a/wails-frontend/src/utils/handleKeyDown.tsx
+++ b/wails-frontend/src/utils/handleKeyDown.tsx
@@ -1,5 +1,9 @@
-export function handleKeyDown(e: React.KeyboardEvent<HTMLFormElement>) {
-  if (e.key === 'Enter') {
-    e.preventDefault();
+export function handleKeyDown(
+  event: React.KeyboardEvent<HTMLFormElement>,
+  handleSubmit: (e: React.SyntheticEvent) => Promise<void>,
+) {
+  if (event.key === 'Enter') {
+    event.preventDefault();
+    handleSubmit(event);
   }
 }

--- a/wails-frontend/src/utils/handleKeyDown.tsx
+++ b/wails-frontend/src/utils/handleKeyDown.tsx
@@ -1,0 +1,5 @@
+export function handleKeyDown(e: React.KeyboardEvent<HTMLFormElement>) {
+  if (e.key === 'Enter') {
+    e.preventDefault();
+  }
+}

--- a/wails-frontend/src/utils/handleKeyDown.tsx
+++ b/wails-frontend/src/utils/handleKeyDown.tsx
@@ -1,5 +1,7 @@
-export function handleKeyDown(e: React.KeyboardEvent<HTMLFormElement>) {
+export function handleKeyDown(e: React.KeyboardEvent) {
   if (e.key === 'Enter') {
     e.preventDefault();
+    console.log('Enter key pressed');
+    // Perform the desired action for the Enter key press
   }
 }


### PR DESCRIPTION
On enter key press password reveal is now prevented. 

current state : 

As a user, when I am signing a transaction using the wails pop-up, I want to click on the "enter" key of my keyboard and that nothing happens.

Objective : 
User flow
As a user, when I am signing a transaction using the wails pop-up, I want to be able to click on the "enter" key of my keyboard and have the action "Sign" selected and pressed.