### PR TITLE
wallet: fix task for build & run on windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ If you want to contribute, please refer to our [CONTRIBUTING](CONTRIBUTING.md) g
 Follow the installation instructions here:
 [task-install](https://taskfile.dev/installation/)
 
+On Windows, we recommend to run `go install github.com/go-task/task/v3/cmd/task@latest` and yo use task commands in a git bash terminal.
+
 ### Install dependencies
 
 ```shell

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -66,8 +66,8 @@ tasks:
   build-windows:
     platforms: [windows]
     cmds:
-      - cmd: mkdir build\wallet-plugin
-      - cmd: go build -tags desktop,production -ldflags "-w -s -H windowsgui" -o build\wallet-plugin\wallet-plugin.exe main.go
+      - cmd: mkdir -p build/wallet-plugin
+      - cmd: go build -tags desktop,production -ldflags "-w -s -H windowsgui" -o build/wallet-plugin/wallet-plugin.exe main.go
 
   build-webapp:
     dir: web-frontend


### PR DESCRIPTION
We are fixing task command for build and run on windows.