### PR TITLE
wails: add absolute path

### DIFF
--- a/wails-frontend/src/main.tsx
+++ b/wails-frontend/src/main.tsx
@@ -9,18 +9,18 @@ import {
 import './index.css';
 import '@massalabs/react-ui-kit/src/global.css';
 
-import App from './app';
-import PasswordPrompt from './pages/passwordPrompt';
-import Success from './pages/success';
-import ImportMethods from './pages/importMethods';
-import ImportFile from './pages/importFile';
-import PromptPrivateKey from './pages/ImportPrivateKey/PromptPrivateKey';
-import PromptNickname from './pages/ImportPrivateKey/PromptNickname';
-import Failure from './pages/failure';
-import BackupMethods from './pages/backupMethods';
-import BackupKeyPairs from './pages/backupKeyPairs';
-import NewPassword from './pages/newPassword';
-import ConfirmDelete from './pages/confirmDelete';
+import App from '@/app';
+import PasswordPrompt from '@/pages/passwordPrompt';
+import Success from '@/pages/success';
+import ImportMethods from '@/pages/importMethods';
+import ImportFile from '@/pages/importFile';
+import PromptPrivateKey from '@/pages/ImportPrivateKey/PromptPrivateKey';
+import PromptNickname from '@/pages/ImportPrivateKey/PromptNickname';
+import Failure from '@/pages/failure';
+import BackupMethods from '@/pages/backupMethods';
+import BackupKeyPairs from '@/pages/backupKeyPairs';
+import NewPassword from '@/pages/newPassword';
+import ConfirmDelete from '@/pages/confirmDelete';
 
 const router = createBrowserRouter(
   createRoutesFromElements(

--- a/wails-frontend/src/pages/ImportPrivateKey/PromptNickname.tsx
+++ b/wails-frontend/src/pages/ImportPrivateKey/PromptNickname.tsx
@@ -1,17 +1,16 @@
 import { SyntheticEvent, useRef, useState } from 'react';
-import { promptRequest } from '../../events/events';
+import { promptRequest } from '@/events/events';
 import { useLocation, useNavigate } from 'react-router-dom';
-import { handleCancel } from '../../utils/utils';
-import { IErrorObject, parseForm } from '../../utils';
+import { IErrorObject, parseForm, handleCancel } from '@/utils';
 import {
   IsNicknameUnique,
   IsNicknameValid,
-} from '../../../wailsjs/go/walletapp/WalletApp';
+} from '@wailsjs/go/walletapp/WalletApp';
 
 import { Input, Button, Stepper } from '@massalabs/react-ui-kit';
-import { Layout } from '../../layouts/Layout/Layout';
+import { Layout } from '@/layouts/Layout/Layout';
 
-import { IMPORT_STEPS } from '../../const/stepper';
+import { IMPORT_STEPS } from '@/const/stepper';
 
 // TODO: create i18n and move this to translation file
 const t = (key: string): string => {

--- a/wails-frontend/src/pages/ImportPrivateKey/PromptPrivateKey.tsx
+++ b/wails-frontend/src/pages/ImportPrivateKey/PromptPrivateKey.tsx
@@ -1,13 +1,12 @@
 import { SyntheticEvent, useRef, useState } from 'react';
-import { promptRequest } from '../../events/events';
 import { useLocation, useNavigate } from 'react-router-dom';
-import { handleCancel } from '../../utils/utils';
-import { IErrorObject, parseForm } from '../../utils';
+import { promptRequest } from '@/events/events';
+import { IErrorObject, parseForm, handleCancel } from '@/utils';
 
 import { Password, Button, Stepper } from '@massalabs/react-ui-kit';
-import { Layout } from '../../layouts/Layout/Layout';
+import { Layout } from '@/layouts/Layout/Layout';
 
-import { IMPORT_STEPS } from '../../const/stepper';
+import { IMPORT_STEPS } from '@/const/stepper';
 
 // TODO: create i18n and move this to translation file
 const t = (key: string): string => {

--- a/wails-frontend/src/pages/backupKeyPairs.tsx
+++ b/wails-frontend/src/pages/backupKeyPairs.tsx
@@ -1,14 +1,14 @@
 import { useState, useRef, SyntheticEvent } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
-import { ClipboardSetText, EventsOnce } from '../../wailsjs/runtime';
-import { events, promptRequest, promptResult } from '../events/events';
-import { parseForm } from '../utils/parseForm';
-import { SendPromptInput } from '../../wailsjs/go/walletapp/WalletApp';
-import { ErrorCode, IErrorObject, handleCancel } from '../utils';
-import Intl from '../i18n/i18n';
+import { ClipboardSetText, EventsOnce } from '@wailsjs/runtime';
+import { events, promptRequest, promptResult } from '@/events/events';
+import { parseForm } from '@/utils/parseForm';
+import { SendPromptInput } from '@wailsjs/go/walletapp/WalletApp';
+import { ErrorCode, IErrorObject, handleCancel } from '@/utils';
+import Intl from '@/i18n/i18n';
 
 import { Password, Button, Clipboard } from '@massalabs/react-ui-kit';
-import { Layout } from '../layouts/Layout/Layout';
+import { Layout } from '@/layouts/Layout/Layout';
 import { FiCopy, FiArrowRight } from 'react-icons/fi';
 
 function EnterKey() {

--- a/wails-frontend/src/pages/backupMethods.tsx
+++ b/wails-frontend/src/pages/backupMethods.tsx
@@ -1,12 +1,12 @@
 import { useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
-import { backupMethods, events, promptRequest } from '../events/events';
-import { EventsOnce } from '../../wailsjs/runtime/runtime';
-import { handleApplyResult } from '../utils';
-import { SendPromptInput } from '../../wailsjs/go/walletapp/WalletApp';
-import Intl from '../i18n/i18n';
+import { backupMethods, events, promptRequest } from '@/events/events';
+import { EventsOnce } from '@wailsjs/runtime/runtime';
+import { handleApplyResult } from '@/utils';
+import { SendPromptInput } from '@wailsjs/go/walletapp/WalletApp';
+import Intl from '@/i18n/i18n';
 
-import { Layout } from '../layouts/Layout/Layout';
+import { Layout } from '@/layouts/Layout/Layout';
 import { Button } from '@massalabs/react-ui-kit';
 
 function BackupMethods() {

--- a/wails-frontend/src/pages/confirmDelete.tsx
+++ b/wails-frontend/src/pages/confirmDelete.tsx
@@ -1,11 +1,11 @@
 import { Button } from '@massalabs/react-ui-kit';
-import { Layout } from '../layouts/Layout/Layout';
+import { Layout } from '@/layouts/Layout/Layout';
 import { useLocation, useNavigate } from 'react-router-dom';
-import { events, promptRequest } from '../events/events';
+import { events, promptRequest } from '@/events/events';
 import { FiAlertTriangle, FiTrash2 } from 'react-icons/fi';
-import { handleApplyResult, handleCancel } from '../utils/utils';
-import { EventsOnce } from '../../wailsjs/runtime/runtime';
-import { SendPromptInput } from '../../wailsjs/go/walletapp/WalletApp';
+import { handleApplyResult, handleCancel } from '@/utils';
+import { EventsOnce } from '@wailsjs/runtime/runtime';
+import { SendPromptInput } from '@wailsjs/go/walletapp/WalletApp';
 
 function ConfirmDelete() {
   const navigate = useNavigate();

--- a/wails-frontend/src/pages/failure.tsx
+++ b/wails-frontend/src/pages/failure.tsx
@@ -1,7 +1,7 @@
 import { useLocation } from 'react-router';
 import { FiX } from 'react-icons/fi';
-import { promptRequest } from '../events/events';
-import { Layout } from '../layouts/Layout/Layout';
+import { promptRequest } from '@/events/events';
+import { Layout } from '@/layouts/Layout/Layout';
 
 const Failure = () => {
   const locationState = useLocation().state as { req: promptRequest };

--- a/wails-frontend/src/pages/importFile.tsx
+++ b/wails-frontend/src/pages/importFile.tsx
@@ -2,15 +2,15 @@ import { useState } from 'react';
 import {
   SendPromptInput,
   SelectAccountFile,
-} from '../../wailsjs/go/walletapp/WalletApp';
-import { events, promptRequest } from '../events/events';
+} from '@wailsjs/go/walletapp/WalletApp';
+import { events, promptRequest } from '@/events/events';
 import { useLocation, useNavigate } from 'react-router-dom';
-import { handleApplyResult, handleCancel } from '../utils/utils';
-import { walletapp } from '../../wailsjs/go/models';
-import { EventsOnce } from '../../wailsjs/runtime/runtime';
+import { handleApplyResult, handleCancel } from '@/utils';
+import { walletapp } from '@wailsjs/go/models';
+import { EventsOnce } from '@wailsjs/runtime/runtime';
 import { Button } from '@massalabs/react-ui-kit';
-import { Layout } from '../layouts/Layout/Layout';
-import Intl from '../i18n/i18n';
+import { Layout } from '@/layouts/Layout/Layout';
+import Intl from '@/i18n/i18n';
 
 const ImportFile = () => {
   const nav = useNavigate();

--- a/wails-frontend/src/pages/importMethods.tsx
+++ b/wails-frontend/src/pages/importMethods.tsx
@@ -1,8 +1,8 @@
-import { promptRequest } from '../events/events';
+import { promptRequest } from '@/events/events';
 import { useLocation, useNavigate } from 'react-router-dom';
 
 import { Button } from '@massalabs/react-ui-kit';
-import { Layout } from '../layouts/Layout/Layout';
+import { Layout } from '@/layouts/Layout/Layout';
 
 const ImportMethods = () => {
   const navigate = useNavigate();

--- a/wails-frontend/src/pages/newPassword.tsx
+++ b/wails-frontend/src/pages/newPassword.tsx
@@ -3,17 +3,20 @@ import { useLocation, useNavigate } from 'react-router-dom';
 import {
   ImportPrivateKey,
   SendPromptInput,
-} from '../../wailsjs/go/walletapp/WalletApp';
-import { EventsOnce } from '../../wailsjs/runtime';
-import { events, promptAction, promptRequest } from '../events/events';
-import { handleApplyResult, handleCancel } from '../utils/utils';
-import { parseForm } from '../utils/parseForm';
-import { hasMoreThanFiveChars, hasSamePassword } from '../validation/password';
+} from '@wailsjs/go/walletapp/WalletApp';
+import { EventsOnce } from '@wailsjs/runtime';
+import { events, promptAction, promptRequest } from '@/events/events';
+import {
+  parseForm,
+  handleApplyResult,
+  handleCancel,
+  IErrorObject,
+} from '@/utils';
+import { hasMoreThanFiveChars, hasSamePassword } from '@/validation/password';
 
 import { FiLock } from 'react-icons/fi';
-import { Layout } from '../layouts/Layout/Layout';
+import { Layout } from '@/layouts/Layout/Layout';
 import { Password, Button, Stepper } from '@massalabs/react-ui-kit';
-import { IErrorObject } from '../utils';
 
 function NewPassword() {
   const navigate = useNavigate();

--- a/wails-frontend/src/pages/passwordPrompt.tsx
+++ b/wails-frontend/src/pages/passwordPrompt.tsx
@@ -1,22 +1,27 @@
 import { useState, useRef, SyntheticEvent, ReactNode } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
-import { SendPromptInput } from '../../wailsjs/go/walletapp/WalletApp';
-import { EventsOnce } from '../../wailsjs/runtime';
+import { SendPromptInput } from '@wailsjs/go/walletapp/WalletApp';
+import { EventsOnce } from '@wailsjs/runtime';
 import {
   events,
   promptAction,
   promptRequest,
   promptResult,
-} from '../events/events';
-import { handleApplyResult, handleCancel } from '../utils/utils';
-import { parseForm } from '../utils/parseForm';
+} from '@/events/events';
+import {
+  parseForm,
+  ErrorCode,
+  IErrorObject,
+  formatStandard,
+  maskAddress,
+  handleApplyResult,
+  handleCancel,
+} from '@/utils';
 
 import { FiLock, FiTrash2 } from 'react-icons/fi';
 import { Password, Button, Balance } from '@massalabs/react-ui-kit';
-import { ErrorCode, IErrorObject } from '../utils';
-import { Layout } from '../layouts/Layout/Layout';
-import Intl from '../i18n/i18n';
-import { formatStandard, maskAddress } from '../utils/massaFormat';
+import { Layout } from '@/layouts/Layout/Layout';
+import Intl from '@/i18n/i18n';
 import { toMAS } from '@massalabs/massa-web3';
 
 interface PromptRequestDeleteData {

--- a/wails-frontend/src/pages/success.tsx
+++ b/wails-frontend/src/pages/success.tsx
@@ -1,8 +1,8 @@
 import { useLocation } from 'react-router';
-import { promptAction, promptRequest } from '../events/events';
+import { promptAction, promptRequest } from '@/events/events';
 import { FiCheck } from 'react-icons/fi';
-import Intl from '../i18n/i18n';
-import { Layout } from '../layouts/Layout/Layout';
+import Intl from '@/i18n/i18n';
+import { Layout } from '@/layouts/Layout/Layout';
 
 function Success() {
   const { state } = useLocation();

--- a/wails-frontend/src/utils/handleApplyResult.tsx
+++ b/wails-frontend/src/utils/handleApplyResult.tsx
@@ -1,10 +1,10 @@
 import { NavigateFunction } from 'react-router-dom';
-import { Hide, AbortAction } from '../../wailsjs/go/walletapp/WalletApp';
-import { WindowReloadApp } from '../../wailsjs/runtime';
-import { promptResult, promptRequest } from '../events/events';
+import { Hide, AbortAction } from '@wailsjs/go/walletapp/WalletApp';
+import { WindowReloadApp } from '@wailsjs/runtime/runtime';
+import { promptResult, promptRequest } from '@/events/events';
 import { IErrorObject } from './errors';
-import Intl from '../i18n/i18n';
-import { useConfigStore } from '../store/store';
+import Intl from '@/i18n/i18n';
+import { useConfigStore } from '@/store/store';
 
 export const handleCancel = () => {
   AbortAction();

--- a/wails-frontend/src/utils/index.tsx
+++ b/wails-frontend/src/utils/index.tsx
@@ -1,3 +1,4 @@
 export * from './errors';
+export * from './handleApplyResult';
+export * from './massaFormat';
 export * from './parseForm';
-export * from './utils';

--- a/wails-frontend/tsconfig.json
+++ b/wails-frontend/tsconfig.json
@@ -15,7 +15,12 @@
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true
+    "noFallthroughCasesInSwitch": true,
+
+    "paths": {
+      "@/*": ["./src/*"],
+      "@wailsjs/*": ["./wailsjs/*"]
+    }
   },
   "include": ["src"],
   "references": [{ "path": "./tsconfig.node.json" }]

--- a/wails-frontend/vite.config.ts
+++ b/wails-frontend/vite.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
+import * as path from 'path';
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -7,6 +8,8 @@ export default defineConfig({
   resolve: {
     alias: {
       events: 'rollup-plugin-node-polyfills/polyfills/events',
+      '@': path.resolve(__dirname, 'src'),
+      '@wailsjs': path.resolve(__dirname, 'wailsjs'),
     },
   },
   build: {


### PR DESCRIPTION
We are adding absolute path in wails-frontend.

**EX:** 
```typescript
-- BEFORE --
import { Component } from '../../components';

-- AFTER -- 
import { Component } from '@/components';
``` 