### PR TITLE
skip invalid yaml in load all accounts

### DIFF
--- a/pkg/wallet/wallet.go
+++ b/pkg/wallet/wallet.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 
 	"github.com/btcsuite/btcutil/base58"
+	"github.com/labstack/gommon/log"
 	"github.com/massalabs/station-massa-wallet/api/server/models"
 	"github.com/massalabs/station-massa-wallet/pkg/utils"
 	"golang.org/x/crypto/pbkdf2"
@@ -245,7 +246,8 @@ func LoadAll() ([]Wallet, error) {
 		if strings.HasPrefix(fileName, "wallet_") && strings.HasSuffix(fileName, ".yaml") {
 			wallet, loadErr := LoadFile(filePath)
 			if loadErr != nil {
-				return nil, loadErr.Err
+				log.Errorf("while loading wallet '%s': %s", filePath, loadErr.Err)
+				continue
 			}
 
 			wallets = append(wallets, wallet)


### PR DESCRIPTION
Imagine in your wallet plugin folder, you have your YAML file, and you have another YAML file that is either poorly formatted or encrypted incorrectly (an old version...). In this case, today, the wallet plugin doesn't work at all because it doesn't display any of your accounts (even the ones that work). You need to manually delete the problematic YAML file. I suggest ignoring all the YAML files that cause problems but still displaying the ones that work so that you can use the plugin.