### PR TITLE
Set Wails Always on Top

### DIFF
--- a/pkg/wails/wails.go
+++ b/pkg/wails/wails.go
@@ -16,6 +16,7 @@ func NewWailsApp(app *wApp.WalletApp, assets embed.FS) *application.Application 
 		Width:       513,
 		Height:      440,
 		StartHidden: true,
+		AlwaysOnTop: true,
 		AssetServer: &assetserver.Options{
 			Assets: assets,
 		},


### PR DESCRIPTION
before : wails popup behaves like normal window 
after : wails popup will be always on top, user can minimize the window but it will not stack under if the user changes focus 